### PR TITLE
specified numpy version at 1.26.x and added decord==0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ dependencies = [
     "torch==2.1.2", "torchvision==0.16.2",
     "transformers==4.43.1", "tokenizers==0.19.0", "sentencepiece==0.1.99", "shortuuid",
     "accelerate==0.29.0", "peft", "bitsandbytes",
-    "pydantic", "markdown2[all]", "numpy", "scikit-learn==1.2.2",
+    "pydantic", "markdown2[all]", "numpy==1.26.4", "scikit-learn==1.2.2",
     "gradio==5.9.1", "gradio_client==1.5.2",
     "requests", "httpx==0.28.1", "uvicorn", "fastapi",
-    "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13",
+    "einops==0.6.1", "einops-exts==0.0.4", "timm==0.6.13", "decord==0.6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Summary
This PR fixes setup errors by updating `pyproject.toml`:

- Pin **NumPy** to `1.26.4`
- Add **Decord** as `0.6.0`

---

# Background
When setting up the environment on **AWS Lambda Cloud (A100 40GB)** using the README Quick Start, I faced two problems:

1. `decord` was not installed  
2. `numpy` was not pinned, so the latest version (2.2) was installed.  
   This caused compatibility errors with other libraries.

See setup logs (errors included):  
https://github.com/HayatoHongo/LLaVA-Mini/blob/main/setup_logs/cleansed/original_setup_cleansed.log

---

# Solution
I updated `pyproject.toml`:

- Added `decord==0.6.0`  
- Pinned `numpy==1.26.4`

After this change, the environment built successfully.  
See setup logs after fix:  
https://github.com/HayatoHongo/LLaVA-Mini/blob/main/setup_logs/cleansed/suggested_setup_cleansed.log

---

# Note
The logs also show a change in `README.md` (setting `flash-attn==2.3.4`),  
but that will be submitted in a **separate PR**.  
This PR only changes `pyproject.toml`.
