### PR TITLE
spcified flash-attn version at 2.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ LLaVA-Mini is a unified large multimodal model that can support the understandin
   conda activate llavamini
   pip install -e .
   pip install -e ".[train]"
-  pip install flash-attn --no-build-isolation
+  pip install flash-attn==2.3.4 --no-build-isolation
   ```
 
 ### Command Interaction


### PR DESCRIPTION
# Summary

By updating the `Quick Start` section of `README.md`, this PR fixes a dependency issue during environment setup:

* Pin `flash-attn` version to **2.3.4**

---

# Background

On 2025/8/30, I set up the environment on **AWS Lambda Cloud (A100 40GB)** following the Quick Start instructions in `README.md`.  
During this process, I faced the following issue:

1. `flash-attn` version was not specified, so the latest version (2.8.3) was installed.  
   This caused conflicts with other dependencies and could not be installed successfully.

Reference (logs with errors, simplified):  
[original_setup_cleansed.log](https://github.com/HayatoHongo/LLaVA-Mini/blob/main/setup_logs/cleansed/original_setup_cleansed.log)

---

# Solution

* Pinned `flash-attn` to version **2.3.4**  
* Updated the `Quick Start` section in `README.md`

After this change, the environment setup completed without errors.

Reference (logs after fix, simplified):  
[suggested_setup_cleansed.log](https://github.com/HayatoHongo/LLaVA-Mini/blob/main/setup_logs/cleansed/suggested_setup_cleansed.log)

---

# Note

The logs also include changes in `pyproject.toml` (pinning `numpy` and adding `decord`).  
However, this PR only modifies **README.md**.  
The changes to `pyproject.toml` will be submitted in a **separate PR**.
